### PR TITLE
add accessibility_contrast slider (0-10) for wcag-compliant contrast adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # mfd.nvim
 
-Monotone colorschemes for Neovim. Aesthetic inspiration from [U.S. Graphics Company](https://usgraphics.com) — thanks for the beautiful work.
-
-Seventeen variants, from phosphor CRTs to night vision.
+Monotone colorschemes for Neovim. Seventeen variants, from phosphor CRTs to night vision display technologies. Inspired by the aesthetics of military MFDs (multi-function displays) and vintage computer terminals.
 
 > [!TIP]  
 > **New:**  
+> `accessibility_contrast` slider (0–10) for [WCAG-compliant contrast](#accessibility).  
 > [`mfd-lumon`](#mfd-lumon) Lumon Industries MDR terminal with CRT phosphor glow.  
 > `mfd-gbl` Game Boy Light electroluminescence, dark and light variants.  
 > `mfd-flir` 4 thermal display schemes.  
 > `mfd-blackout` true black, ultra-low contrast for late night use.  
-> `bright_comments` option increases comment visibility for all themes.  
 
 
 ## Themes
@@ -42,7 +40,8 @@ Deep red.
 ![MFD-SCARLET](screenshots/mfd-scarlet.png)
 
 ### MFD-PAPER
-High contrast terminal.
+High contrast terminal. Aesthetic inspiration from [U.S. Graphics Company](https://usgraphics.com) - thanks for the beautiful work.
+
 
 ![MFD-PAPER](screenshots/mfd-paper.png)
 
@@ -154,10 +153,39 @@ Call `setup()` before setting the colorscheme:
 
 ```lua
 require('mfd').setup({
-  bright_comments = true, -- increase comment visibility (default: false)
-  no_italic = true,       -- disable italic highlighting (default: false)
+  accessibility_contrast = 0, -- 0 (default) to 10 (max WCAG compliance)
+  no_italic = true,           -- disable italic highlighting (default: false)
+  bright_comments = true,     -- legacy: equivalent to accessibility_contrast = 4
 })
 ```
+
+## Accessibility
+
+`accessibility_contrast` lifts dim elements (comments, line numbers, inlay hints, borders) toward WCAG compliance while preserving each theme's hue.
+
+Even small values make a noticeable difference. You'll likely find a comfortable level well before reaching formal WCAG thresholds. Your environment brightness matters too; a theme like mfd-blackout is perfectly readable in a dark room but benefits from a higher level in daylight.
+
+| Theme | Level 5 | Level 10 |
+|---|---|---|
+| mfd | 1.5 | AA-UI (3.01) |
+| mfd-dark | AA-UI | AAA |
+| mfd-stealth | AA-UI | AAA |
+| mfd-amber | AA-UI | AAA |
+| mfd-mono | AA-UI | AAA |
+| mfd-scarlet | 2.7 | AAA |
+| mfd-paper | 2.6 | AAA |
+| mfd-hud | AA-UI | AAA |
+| mfd-nvg | AA-UI | AAA |
+| mfd-gbl-light | AA-UI | AAA |
+| mfd-gbl-dark | AA-UI | AAA |
+| mfd-lumon | AA-UI | AAA |
+| mfd-flir | 2.8 | AAA |
+| mfd-flir-bh | 2.6 | AAA |
+| mfd-flir-rh | 2.8 | AAA |
+| mfd-flir-fusion | 2.6 | AA (6.56) |
+| mfd-blackout | 2.6 | AAA |
+
+AA-UI ≥ 3.0 / AA ≥ 4.5 / AAA ≥ 7.0
 
 ## License
 

--- a/colors/mfd-amber.lua
+++ b/colors/mfd-amber.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#141008',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#7A5830'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-blackout.lua
+++ b/colors/mfd-blackout.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#060808',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#303438'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-dark.lua
+++ b/colors/mfd-dark.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#253525',  -- floating windows (slightly lighter than bg)
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#607258'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-flir-bh.lua
+++ b/colors/mfd-flir-bh.lua
@@ -16,12 +16,12 @@ local c = {
   float_bg = '#BCBCBC',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#707070'
-end
+local cursor_dim = c.dim
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)
@@ -40,11 +40,11 @@ hi('lCursor',      { fg = c.bg, bg = c.bright })
 hi('CursorIM',     { fg = c.bg, bg = c.bright })
 hi('TermCursor',   { fg = c.bg, bg = c.bright })
 hi('TermCursorNC', { fg = c.bg, bg = c.dim })
-hi('CursorNormal',  { fg = c.fg, bg = c.dim })
+hi('CursorNormal',  { fg = c.fg, bg = cursor_dim })
 hi('CursorInsert',  { fg = c.fg, bg = '#787878' })
 hi('CursorVisual',  { fg = c.bg, bg = '#808080' })
 hi('CursorReplace', { fg = c.bg, bg = '#585858' })
-hi('CursorCommand', { fg = c.fg, bg = c.dim })
+hi('CursorCommand', { fg = c.fg, bg = cursor_dim })
 hi('CursorLine',   { bg = c.cursor })
 hi('CursorColumn', { bg = c.cursor })
 hi('LineNr',       { fg = c.subtle })

--- a/colors/mfd-flir-fusion.lua
+++ b/colors/mfd-flir-fusion.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#1C0C22',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#7A4880'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-flir-rh.lua
+++ b/colors/mfd-flir-rh.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#1C1C1C',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#707070'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-flir.lua
+++ b/colors/mfd-flir.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#1C1C1C',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#707070'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-gbl-dark.lua
+++ b/colors/mfd-gbl-dark.lua
@@ -16,12 +16,12 @@ local c = {
 	float_bg = "#004F3A", -- floating windows
 }
 
-local comment = c.dim
-if require("mfd").config.bright_comments then
-	comment = "#009A70"
-end
+local cursor_dim = c.dim
+local mfd = require("mfd")
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require("mfd").config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
 	if no_italic then opts.italic = nil end
 	vim.api.nvim_set_hl(0, group, opts)
@@ -40,11 +40,11 @@ hi("lCursor", { fg = c.bg, bg = c.fg })
 hi("CursorIM", { fg = c.bg, bg = c.fg })
 hi("TermCursor", { fg = c.bg, bg = c.fg })
 hi("TermCursorNC", { fg = c.bg, bg = c.dim })
-hi("CursorNormal", { fg = c.bg, bg = "#2A4A2A" }) -- saturated dark green
-hi("CursorInsert", { fg = c.bg, bg = "#0D1D0D" }) -- near-black green, max contrast
-hi("CursorVisual", { fg = c.bg, bg = "#3A5A3A" }) -- medium green, lifted
-hi("CursorReplace", { fg = c.bg, bg = "#1A3A1A" }) -- deep green, between normal/insert
-hi("CursorCommand", { fg = c.bg, bg = "#2A4A2A" }) -- same as normal
+hi("CursorNormal", { fg = c.bg, bg = c.dim })
+hi("CursorInsert", { fg = c.bg, bg = "#0D1D0D" })
+hi("CursorVisual", { fg = c.bg, bg = "#3A5A3A" })
+hi("CursorReplace", { fg = c.bg, bg = "#1A3A1A" })
+hi("CursorCommand", { fg = c.bg, bg = c.dim })
 hi("CursorLine", { bg = c.cursor })
 hi("CursorColumn", { bg = c.cursor })
 hi("LineNr", { fg = c.subtle })

--- a/colors/mfd-gbl-light.lua
+++ b/colors/mfd-gbl-light.lua
@@ -16,12 +16,12 @@ local c = {
 	float_bg = "#02B582", -- floating windows
 }
 
-local comment = c.dim
-if require("mfd").config.bright_comments then
-	comment = "#004F3A"
-end
+local cursor_dim = c.dim
+local mfd = require("mfd")
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require("mfd").config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
 	if no_italic then opts.italic = nil end
 	vim.api.nvim_set_hl(0, group, opts)
@@ -40,11 +40,11 @@ hi("lCursor", { fg = c.bg, bg = c.fg })
 hi("CursorIM", { fg = c.bg, bg = c.fg })
 hi("TermCursor", { fg = c.bg, bg = c.fg })
 hi("TermCursorNC", { fg = c.bg, bg = c.dim })
-hi("CursorNormal", { fg = c.bg, bg = "#2A4A2A" }) -- saturated dark green
-hi("CursorInsert", { fg = c.bg, bg = "#0D1D0D" }) -- near-black green, max contrast
-hi("CursorVisual", { fg = c.bg, bg = "#3A5A3A" }) -- medium green, lifted
-hi("CursorReplace", { fg = c.bg, bg = "#1A3A1A" }) -- deep green, between normal/insert
-hi("CursorCommand", { fg = c.bg, bg = "#2A4A2A" }) -- same as normal
+hi("CursorNormal", { fg = c.bg, bg = cursor_dim })
+hi("CursorInsert", { fg = c.bg, bg = "#0D1D0D" })
+hi("CursorVisual", { fg = c.bg, bg = "#3A5A3A" })
+hi("CursorReplace", { fg = c.bg, bg = "#1A3A1A" })
+hi("CursorCommand", { fg = c.bg, bg = cursor_dim })
 hi("CursorLine", { bg = c.cursor })
 hi("CursorColumn", { bg = c.cursor })
 hi("LineNr", { fg = c.subtle })

--- a/colors/mfd-hud.lua
+++ b/colors/mfd-hud.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#081008',
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#387038'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-lumon.lua
+++ b/colors/mfd-lumon.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#0C1822',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#2A5868'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
 

--- a/colors/mfd-mono.lua
+++ b/colors/mfd-mono.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#0C0C10',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#606068'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-nvg.lua
+++ b/colors/mfd-nvg.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#182416',
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#609848'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-paper.lua
+++ b/colors/mfd-paper.lua
@@ -16,12 +16,12 @@ local c = {
   float_bg = '#C5CFC2',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#3A5038'
-end
+local cursor_dim = c.dim
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)
@@ -40,11 +40,11 @@ hi('lCursor',      { fg = c.bg, bg = c.bright })
 hi('CursorIM',     { fg = c.bg, bg = c.bright })
 hi('TermCursor',   { fg = c.bg, bg = c.bright })
 hi('TermCursorNC', { fg = c.bg, bg = c.dim })
-hi('CursorNormal',  { fg = c.fg, bg = c.dim })
+hi('CursorNormal',  { fg = c.fg, bg = cursor_dim })
 hi('CursorInsert',  { fg = c.fg, bg = '#6A7A68' })
 hi('CursorVisual',  { fg = c.bg, bg = '#3A6A3A' })
 hi('CursorReplace', { fg = c.bg, bg = '#0A3018' })
-hi('CursorCommand', { fg = c.fg, bg = c.dim })
+hi('CursorCommand', { fg = c.fg, bg = cursor_dim })
 hi('CursorLine',   { bg = c.cursor })
 hi('CursorColumn', { bg = c.cursor })
 hi('LineNr',       { fg = c.subtle })

--- a/colors/mfd-scarlet.lua
+++ b/colors/mfd-scarlet.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#100505',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#8A4038'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd-stealth.lua
+++ b/colors/mfd-stealth.lua
@@ -16,12 +16,11 @@ local c = {
   float_bg = '#101810',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#4A6A4A'
-end
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)

--- a/colors/mfd.lua
+++ b/colors/mfd.lua
@@ -16,12 +16,19 @@ local c = {
   float_bg = '#5A6B4A',  -- floating windows
 }
 
-local comment = c.dim
-if require('mfd').config.bright_comments then
-  comment = '#354828'
+local cursor_dim = c.dim
+local mfd = require('mfd')
+c = mfd.compute_accessible_colors(c, mfd.get_contrast_level())
+
+-- on this mid-tone theme, fg goes dark at high contrast. the cursor block must
+-- contrast against both bg and the dark text inside it. use a light olive that
+-- stands out from the bg but lets dark text show through.
+if mfd.get_contrast_level() > 0 then
+  cursor_dim = '#B0BFA0'
 end
 
-local no_italic = require('mfd').config.no_italic
+local comment = c.dim
+local no_italic = mfd.config.no_italic
 local function hi(group, opts)
   if no_italic then opts.italic = nil end
   vim.api.nvim_set_hl(0, group, opts)
@@ -40,11 +47,11 @@ hi('lCursor',      { fg = c.bg, bg = c.bright })
 hi('CursorIM',     { fg = c.bg, bg = c.bright })
 hi('TermCursor',   { fg = c.bg, bg = c.bright })
 hi('TermCursorNC', { fg = c.bg, bg = c.dim })
-hi('CursorNormal',  { fg = c.fg, bg = c.dim })
-hi('CursorInsert',  { fg = c.fg, bg = "#3A5A3A" })
+hi('CursorNormal',  { fg = c.bg, bg = cursor_dim })
+hi('CursorInsert',  { fg = c.bg, bg = cursor_dim })
 hi('CursorVisual',  { fg = c.bg, bg = '#3A5A3A' })
 hi('CursorReplace', { fg = c.bg, bg = '#1A3A1A' })
-hi('CursorCommand', { fg = c.fg, bg = c.dim })
+hi('CursorCommand', { fg = c.bg, bg = cursor_dim })
 hi('CursorLine',   { bg = c.cursor })
 hi('CursorColumn', { bg = c.cursor })
 hi('LineNr',       { fg = c.subtle })

--- a/lua/mfd/init.lua
+++ b/lua/mfd/init.lua
@@ -4,8 +4,9 @@
 local M = {}
 
 M.config = {
-	bright_comments = false,
+	bright_comments = false, -- back-compat - resolves to accessibility_contrast 4 if true
 	no_italic = false,
+	accessibility_contrast = 0,
 }
 
 function M.setup(opts)
@@ -148,6 +149,292 @@ M.palettes = {
 		float_bg = "#0C1822",
 	},
 }
+
+-- color math for accessibility contrast
+local function hex_to_rgb(hex)
+	hex = hex:gsub("#", "")
+	return tonumber(hex:sub(1, 2), 16) / 255,
+		tonumber(hex:sub(3, 4), 16) / 255,
+		tonumber(hex:sub(5, 6), 16) / 255
+end
+
+local function rgb_to_hex(r, g, b)
+	return string.format("#%02X%02X%02X",
+		math.max(0, math.min(255, math.floor(r * 255 + 0.5))),
+		math.max(0, math.min(255, math.floor(g * 255 + 0.5))),
+		math.max(0, math.min(255, math.floor(b * 255 + 0.5))))
+end
+
+local function rgb_to_hsv(r, g, b)
+	local max_c = math.max(r, g, b)
+	local min_c = math.min(r, g, b)
+	local delta = max_c - min_c
+	local h, s, v = 0, 0, max_c
+	if max_c > 0 then s = delta / max_c end
+	if delta > 0 then
+		if max_c == r then h = ((g - b) / delta) % 6
+		elseif max_c == g then h = (b - r) / delta + 2
+		else h = (r - g) / delta + 4 end
+		h = h / 6
+	end
+	return h, s, v
+end
+
+local function hsv_to_rgb(h, s, v)
+	if s == 0 then return v, v, v end
+	local i = math.floor(h * 6)
+	local f = h * 6 - i
+	local p = v * (1 - s)
+	local q = v * (1 - f * s)
+	local t = v * (1 - (1 - f) * s)
+	i = i % 6
+	if i == 0 then return v, t, p
+	elseif i == 1 then return q, v, p
+	elseif i == 2 then return p, v, t
+	elseif i == 3 then return p, q, v
+	elseif i == 4 then return t, p, v
+	else return v, p, q end
+end
+
+local function srgb_linearize(c)
+	if c <= 0.04045 then return c / 12.92 end
+	return ((c + 0.055) / 1.055) ^ 2.4
+end
+
+local function relative_luminance(r, g, b)
+	return 0.2126 * srgb_linearize(r) + 0.7152 * srgb_linearize(g) + 0.0722 * srgb_linearize(b)
+end
+
+local function contrast_ratio(hex1, hex2)
+	local r1, g1, b1 = hex_to_rgb(hex1)
+	local r2, g2, b2 = hex_to_rgb(hex2)
+	local l1 = relative_luminance(r1, g1, b1)
+	local l2 = relative_luminance(r2, g2, b2)
+	local lighter = math.max(l1, l2)
+	local darker = math.min(l1, l2)
+	return (lighter + 0.05) / (darker + 0.05)
+end
+
+local function lerp_hsv(hex1, hex2, t)
+	local r1, g1, b1 = hex_to_rgb(hex1)
+	local r2, g2, b2 = hex_to_rgb(hex2)
+	local h1, s1, v1 = rgb_to_hsv(r1, g1, b1)
+	local h2, s2, v2 = rgb_to_hsv(r2, g2, b2)
+	local r, g, b = hsv_to_rgb(
+		h1 + (h2 - h1) * t,
+		s1 + (s2 - s1) * t,
+		v1 + (v2 - v1) * t)
+	return rgb_to_hex(r, g, b)
+end
+
+-- find the color with same hue+sat that hits target contrast against all bg surfaces.
+-- returns the original color unchanged if it already meets the target.
+local function find_target_color(src_hex, bg_surfaces, target, direction)
+	if #bg_surfaces == 0 then return src_hex, true end
+
+	local meets_all = true
+	for _, bg in ipairs(bg_surfaces) do
+		if contrast_ratio(src_hex, bg) < target then
+			meets_all = false
+			break
+		end
+	end
+	if meets_all then return src_hex, true end
+
+	local r, g, b = hex_to_rgb(src_hex)
+	local h, s, v = rgb_to_hsv(r, g, b)
+
+	-- check if max possible brightness/darkness can reach target
+	local extreme_v = direction == "lighter" and 1.0 or 0.0
+	local er, eg, eb = hsv_to_rgb(h, s, extreme_v)
+	local extreme_hex = rgb_to_hex(er, eg, eb)
+	local can_reach = true
+	for _, bg in ipairs(bg_surfaces) do
+		if contrast_ratio(extreme_hex, bg) < target then
+			can_reach = false
+			break
+		end
+	end
+	if not can_reach then return extreme_hex, false end
+
+	-- binary search for the exact value
+	local lo, hi
+	if direction == "lighter" then lo, hi = v, 1.0
+	else lo, hi = 0.0, v end
+
+	for _ = 1, 50 do
+		local mid = (lo + hi) / 2
+		local mr, mg, mb = hsv_to_rgb(h, s, mid)
+		local mid_hex = rgb_to_hex(mr, mg, mb)
+		local ok = true
+		for _, bg in ipairs(bg_surfaces) do
+			if contrast_ratio(mid_hex, bg) < target then
+				ok = false
+				break
+			end
+		end
+		if direction == "lighter" then
+			if ok then hi = mid else lo = mid end
+		else
+			if ok then lo = mid else hi = mid end
+		end
+	end
+
+	local fr, fg_, fb = hsv_to_rgb(h, s, (lo + hi) / 2)
+	return rgb_to_hex(fr, fg_, fb), true
+end
+
+-- darken (dark themes) or lighten (light themes) a bg just enough for fg to hit target
+local function adjust_bg(fg_hex, bg_hex, target, is_light)
+	if contrast_ratio(fg_hex, bg_hex) >= target then return bg_hex end
+	local r, g, b = hex_to_rgb(bg_hex)
+	local h, s, v = rgb_to_hsv(r, g, b)
+	local lo, hi
+	if is_light then lo, hi = v, 1.0 else lo, hi = 0.0, v end
+	for _ = 1, 50 do
+		local mid = (lo + hi) / 2
+		local mr, mg, mb = hsv_to_rgb(h, s, mid)
+		local mid_hex = rgb_to_hex(mr, mg, mb)
+		if contrast_ratio(fg_hex, mid_hex) >= target then
+			if is_light then hi = mid else lo = mid end
+		else
+			if is_light then lo = mid else hi = mid end
+		end
+	end
+	-- take the side that guaranteed meets the target
+	local final_v = is_light and hi or lo
+	local fr, fg_, fb = hsv_to_rgb(h, s, final_v)
+	local result = rgb_to_hex(fr, fg_, fb)
+	if contrast_ratio(fg_hex, result) >= target then return result end
+	return is_light and "#FFFFFF" or "#000000"
+end
+
+-- compute accessible palette from base palette and contrast level (0-10).
+-- returns a new table with adjusted colors, or the original palette at level 0.
+function M.compute_accessible_colors(palette, level)
+	if level == 0 then return palette end
+
+	-- detect light theme: fg is darker than bg
+	local fg_lum = relative_luminance(hex_to_rgb(palette.fg))
+	local bg_lum = relative_luminance(hex_to_rgb(palette.bg))
+	local is_light = fg_lum < bg_lum
+	local direction = is_light and "darker" or "lighter"
+
+	local bg_surfaces = { palette.bg, palette.float_bg, palette.cursor }
+	local fg_keys = { "dim", "subtle", "border", "fg", "bright", "glow" }
+	local bg_keys = { "bg", "cursor", "float_bg", "visual" }
+
+	-- compute level 10 targets: exact color needed for 7.0 against all bg surfaces
+	-- target 7.1 to absorb rounding in the binary search
+	local targets = {}
+	local all_reached = true
+	for _, key in ipairs(fg_keys) do
+		if palette[key] then
+			local target_hex, reached = find_target_color(palette[key], bg_surfaces, 7.1, direction)
+			targets[key] = target_hex
+			if not reached then all_reached = false end
+		end
+	end
+
+	-- interpolate between current and target based on level
+	local t = level / 10.0
+	local result = {}
+	for k, v in pairs(palette) do
+		result[k] = v
+	end
+
+	for _, key in ipairs(fg_keys) do
+		if targets[key] then
+			result[key] = lerp_hsv(palette[key], targets[key], t)
+		end
+	end
+
+	-- on light themes, dim/subtle/border start lighter than fg and all go darker.
+	-- they must not converge with fg, otherwise cursor blocks become invisible.
+	-- ensure a minimum contrast of 1.2 between each and fg.
+	if is_light and result.fg then
+		local min_sep = 1.2
+		for _, key in ipairs({"dim", "subtle", "border"}) do
+			if result[key] and palette[key] then
+				local orig_key_lum = relative_luminance(hex_to_rgb(palette[key]))
+				local orig_fg_lum = relative_luminance(hex_to_rgb(palette.fg))
+				if orig_key_lum > orig_fg_lum and contrast_ratio(result[key], result.fg) < min_sep then
+					local r, g, b = hex_to_rgb(palette[key])
+					local h, s, _ = rgb_to_hsv(r, g, b)
+					local lo, hi_v = 0.0, 1.0
+					for _ = 1, 50 do
+						local mid = (lo + hi_v) / 2
+						local mr, mg, mb = hsv_to_rgb(h, s, mid)
+						local mid_hex = rgb_to_hex(mr, mg, mb)
+						if contrast_ratio(mid_hex, result.fg) >= min_sep then
+							hi_v = mid
+						else
+							lo = mid
+						end
+					end
+					local dr, dg, db = hsv_to_rgb(h, s, hi_v)
+					result[key] = rgb_to_hex(dr, dg, db)
+				end
+			end
+		end
+	end
+
+	-- recheck whether all colors actually hit 7.0 after any capping
+	if level == 10 then
+		all_reached = true
+		for _, key in ipairs(fg_keys) do
+			if result[key] then
+				for _, bg in ipairs(bg_surfaces) do
+					if contrast_ratio(result[key], bg) < 7.0 then
+						all_reached = false
+						break
+					end
+				end
+			end
+			if not all_reached then break end
+		end
+	end
+
+	-- at level 10 only: if fg can't reach AAA, adjust backgrounds.
+	-- for light themes, cap the adjustment to avoid destroying the theme.
+	if level == 10 and not all_reached then
+		for _, bg_key in ipairs(bg_keys) do
+			if result[bg_key] then
+				local adjusted = result[bg_key]
+				for _, fg_key in ipairs(fg_keys) do
+					if result[fg_key] and contrast_ratio(result[fg_key], adjusted) < 7.0 then
+						adjusted = adjust_bg(result[fg_key], adjusted, 7.0, is_light)
+					end
+				end
+				-- on light themes with mid-range backgrounds (like mfd base), the
+				-- adjustment can push bg to extremes. cap so bg doesn't shift more
+				-- than 50% of its original luminance.
+				if is_light and palette[bg_key] then
+					local orig_lum = relative_luminance(hex_to_rgb(palette[bg_key]))
+					local new_lum = relative_luminance(hex_to_rgb(adjusted))
+					if math.abs(new_lum - orig_lum) > orig_lum * 0.5 then
+						adjusted = palette[bg_key]
+					end
+				end
+				result[bg_key] = adjusted
+			end
+		end
+	end
+
+	return result
+end
+
+-- resolve the effective accessibility_contrast level from config
+function M.get_contrast_level()
+	local c = M.config
+	if c.accessibility_contrast > 0 then
+		return c.accessibility_contrast
+	end
+	if c.bright_comments then
+		return 4
+	end
+	return 0
+end
 
 -- Get palette for current or specified colorscheme
 function M.get_palette(scheme)


### PR DESCRIPTION
adds a `accessibility_contrast` setting which gives a maximum of WCAG AAA (7.0) for most themes. 

The setting provides a scale which is visually linear, but the WCAG score is not linear so you're looking at level 7 or 8 to be hitting AA (text) and 10 for AAA - however you will likely find something comfortable way before hitting those levels. (My own preference is 0 😄)

Fixes #7 


| theme | lvl 5 | lvl 10 |
|---|---|---|
| mfd | 1.5 | AA-UI (3.01) |
| mfd-dark | AA-UI | AAA |
| mfd-stealth | AA-UI | AAA |
| mfd-amber | AA-UI | AAA |
| mfd-mono | AA-UI | AAA |
| mfd-scarlet | 2.7 | AAA |
| mfd-paper | 2.6 | AAA |
| mfd-hud | AA-UI | AAA |
| mfd-nvg | AA-UI | AAA |
| mfd-gbl-light | AA-UI | AAA |
| mfd-gbl-dark | AA-UI | AAA |
| mfd-lumon | AA-UI | AAA |
| mfd-flir | 2.8 | AAA |
| mfd-flir-bh | 2.6 | AAA |
| mfd-flir-rh | 2.8 | AAA |
| mfd-flir-fusion | 2.6 | AA (6.56) |
| mfd-blackout | 2.6 | AAA |

